### PR TITLE
Added support for enum values in expressions

### DIFF
--- a/src/expressive.annotations.validate.js
+++ b/src/expressive.annotations.validate.js
@@ -69,6 +69,10 @@
                 boolResult = analyser.Utils.Bool.tryParse(targetValue);
                 targetValue = boolResult.error ? targetValue.trim() : boolResult;
             }
+            if (!isNaN(parseFloat(dependentValue)) && isFinite(dependentValue) && !isNaN(parseFloat(targetValue)) && isFinite(targetValue)) {
+                dependentValue = parseFloat(dependentValue);
+                targetValue = parseFloat(targetValue);
+            }
             return (dependentValue === targetValue) || (dependentValue !== '' && targetValue === '*');
         },
         greater: function (dependentValue, targetValue) {


### PR DESCRIPTION
Tried an expression like:

``` C#
[RequiredIfExpression(Expression = "!{0}", DependentProperties = new[] { "Schedule" }, TargetValues = new object[] { AgreementSchedule.Custom }, ErrorMessage = "required for non-custom schedules.")]
```

Looks like the attribute renders a numeric comparison, but the dependent property gives a string.

I fixed by converting to numeric if both sides are numeric.
