### PR TITLE
Prevent errors from Assembly.GetTypes() from breaking Enum searches

### DIFF
--- a/src/ExpressiveAnnotations/Analysis/Parser.cs
+++ b/src/ExpressiveAnnotations/Analysis/Parser.cs
@@ -434,7 +434,8 @@ namespace ExpressiveAnnotations.Analysis
             {
                 name = string.Join(".", parts.Take(parts.Count() - 1).ToList());
                 var enumTypes = AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(a => a.GetTypes()).Where(t => t.IsEnum && t.FullName.EndsWith(name)).ToList();
+                    .SelectMany(a => { try { return a.GetTypes(); } catch { return new Type[] { }; } })
+                    .Where(t => t.IsEnum && t.FullName.EndsWith(name)).ToList();
 
                 if (enumTypes.Count() > 1)
                     throw new ArgumentException(string.Format("Dynamic extraction failed. {0} enum identifier is ambigous. Provide namespace.", name), name);


### PR DESCRIPTION
Sometimes Assembly.GetTypes() can fail for random reasons. Just eat such exceptions and go on to the next Assembly.
