### PR TITLE
#214 Concurrent validation using RequiredIfAttribute throws NullReferenceException

### DIFF
--- a/src/ExpressiveAnnotations/Attributes/ExpressiveAttribute.cs
+++ b/src/ExpressiveAnnotations/Attributes/ExpressiveAttribute.cs
@@ -287,7 +287,8 @@ namespace ExpressiveAnnotations.Attributes
 
         private void AdjustMemberName(ValidationContext validationContext) // fixes for: MVC <= 4 (MemberName is not provided), WebAPI 2 (MemberName states for display name)
         {
-            PropertyType = null; // reset value
+            if (PropertyType != null) return;
+
             if (validationContext.MemberName == null && validationContext.DisplayName == null)
                 return;
 


### PR DESCRIPTION
Fixing ExpressiveAttribute temporarily setting PropertyType to null on a shared attribute instance, causing other threads to throw NullReferenceException
